### PR TITLE
Logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "0.0.6"
 
 scalaVersion := "2.10.3"
 
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
+
 crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3")
 
 crossVersion := CrossVersion.binary
@@ -11,19 +13,9 @@ crossVersion := CrossVersion.binary
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "1.9.1" % "test",
+  "com.typesafe.akka" %% "akka-actor" % "2.2.1",
   "com.typesafe.akka" %% "akka-testkit" % "2.2.1" % "test",
-  "com.typesafe.akka" %% "akka-agent" % "2.2.1",
-  "com.typesafe" %% "scalalogging-slf4j" % "1.0.1",
-  "org.slf4j" % "slf4j-api" % "1.7.1",
-  "ch.qos.logback" % "logback-classic" % "1.0.3"
-)
-
-testOptions in Test += Tests.Setup(classLoader =>
-  classLoader
-    .loadClass("org.slf4j.LoggerFactory")
-    .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
-    .invoke(null, "ROOT")
+  "org.scalatest" %% "scalatest" % "1.9.1" % "test"
 )
 
 publishTo <<= version { v: String =>

--- a/src/main/scala/com/beachape/filemanagement/CallbackActor.scala
+++ b/src/main/scala/com/beachape/filemanagement/CallbackActor.scala
@@ -1,7 +1,6 @@
 package com.beachape.filemanagement
 
 import akka.actor.{Actor, Props}
-import com.typesafe.scalalogging.slf4j.Logging
 import com.beachape.filemanagement.Messages.PerformCallback
 
 /**
@@ -25,9 +24,8 @@ object CallbackActor {
  *
  * Should be created via companion method's props
  */
-class CallbackActor extends Actor with Logging {
+class CallbackActor extends Actor {
   def receive = {
     case PerformCallback(path, callback) => callback(path)
-    case _ => logger.error("Unknown message received")
   }
 }

--- a/src/main/scala/com/beachape/filemanagement/RecursiveFileActions.scala
+++ b/src/main/scala/com/beachape/filemanagement/RecursiveFileActions.scala
@@ -1,14 +1,13 @@
 package com.beachape.filemanagement
 
 import com.beachape.filemanagement.RegistryTypes._
-import com.typesafe.scalalogging.slf4j.Logging
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, SimpleFileVisitor, Files, Path}
 
 /**
  * Trait for allowing a block of code to be run recursively given a directory path
  */
-trait RecursiveFileActions extends Logging {
+trait RecursiveFileActions {
 
   /**
    * Recursively performs an action given a directory path
@@ -28,6 +27,5 @@ trait RecursiveFileActions extends Logging {
           FileVisitResult.CONTINUE
         }
       })
-    else logger.debug(s"Path '$path' is not a directory, skipping recursive action")
   }
 }


### PR DESCRIPTION
Currently, logging is being done in 4 places in the schwatcher library:
- CallbackActor (1)
- WatchServiceTask (4)
- MonitorActor (5)
- RecursiveFileActions (1)

The logging in `CallbackActor` is debug logging to catch any unknown messages. `CallbackActor` only receives one type of message (`PerformCallback`) and only from `MonitorActor`, so I think it's safe to drop this one.

`RecursiveFileActions` only logs if `forEachDir` is called on a file and just logs the error. In this case it might be appropriate to throw an `IllegalArgumentException`, since if a user is calling `forEachDir` on a file that is probably a big oversight and we should bring it to their attention with an exception. At the least, this logging is also safe to remove.

The logging in `WatchServiceTask` and `MonitorActor` is a bit more substantial, but doesn't report anything critical.

From my perspective as a user of schwatcher, I'd rather have the library perform no logging and let me log around the library as needed. As well, logging is adding 3 dependencies to this otherwise very lightweight library (logback-classic, scalalogging-slf4j, slf4j-api). I don't think the benefits from logging some debug messages is worth these extra dependencies.

Finally, I sometimes get this output from SLF4J when I start up my application:

SLF4J: The following loggers will not work because they were created
SLF4J: during the default configuration phase of the underlying logging system.
SLF4J: See also http://www.slf4j.org/codes.html#substituteLogger
SLF4J: com.beachape.filemanagement.MonitorActor

I'm not very familiar with SLF4J so I don't know what's causing this, or if there's an easy fix, but removing logging certainly prevents this from happening :)

I've attached a pull request that drops these logging dependencies and removes logging from the library. What do you think?
