### PR TITLE
Add feature for specify Modifier on WatchService registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ val desktopFile = Paths get "/Users/lloyd/Desktop/test"
  */
 fileMonitorActor ! RegisterCallback(
   ENTRY_MODIFY,
+  None,
   recursive = false,
   path = desktopFile,
   modifyCallbackFile)
@@ -87,6 +88,7 @@ fileMonitorActor ! RegisterCallback(
 */
 fileMonitorActor ! RegisterCallback(
   ENTRY_MODIFY,
+  None,
   recursive = false,
   path = desktop,
   modifyCallbackDirectory)

--- a/src/main/scala/com/beachape/filemanagement/Messages.scala
+++ b/src/main/scala/com/beachape/filemanagement/Messages.scala
@@ -2,6 +2,7 @@ package com.beachape.filemanagement
 
 import com.beachape.filemanagement.RegistryTypes._
 import java.nio.file.{Path, WatchEvent}
+import java.nio.file.WatchEvent.Modifier
 import scala.language.existentials
 
 /*
@@ -30,6 +31,7 @@ object Messages{
    */
   sealed case class RegisterCallback(
                                       event: WatchEvent.Kind[Path],
+                                      modifier: Option[Modifier] = None,
                                       recursive: Boolean = false,
                                       path: Path,
                                       callback: Callback)

--- a/src/main/scala/com/beachape/filemanagement/WatchServiceTask.scala
+++ b/src/main/scala/com/beachape/filemanagement/WatchServiceTask.scala
@@ -5,6 +5,7 @@ import collection.JavaConversions._
 import com.beachape.filemanagement.Messages.EventAtPath
 import java.nio.file.StandardWatchEventKinds._
 import java.nio.file.{WatchKey, WatchEvent, Path, FileSystems}
+import java.nio.file.WatchEvent.Modifier
 
 
 /**
@@ -66,13 +67,24 @@ class WatchServiceTask(notifyActor: ActorRef) extends Runnable {
    *
    * @param path Path (Java7) path
    * @param eventType WatchEvent.Kind[Path], one of ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE
+   * @param modifier  Option[Modifier], the modifiers, if any, that modify how the object is registered
    * @return Option[WatchKey] a Java7 WatchService WatchKey
    */
-  def watch(path: Path, eventType: WatchEvent.Kind[Path]): Option[WatchKey] = {
+  def watch(path: Path, eventType: WatchEvent.Kind[Path], modifier: Option[Modifier]): Option[WatchKey] = {
     val fileAtPath = path.toFile
-    if (fileAtPath.isDirectory) Some(path.register(watchService, eventType))
-    else if (fileAtPath.isFile) Some(path.getParent.register(watchService, eventType))
-    else None
+    if (fileAtPath.isDirectory) {
+      modifier match {
+        case Some(modifier) => Some(path.register(watchService, Array[WatchEvent.Kind[_]](eventType), modifier))
+        case None           => Some(path.register(watchService, eventType))
+      }
+    } else if (fileAtPath.isFile) {
+      modifier match {
+        case Some(modifier) => Some(path.getParent.register(watchService, Array[WatchEvent.Kind[_]](eventType), modifier))
+        case None           => Some(path.getParent.register(watchService, eventType))
+      }
+    }else {
+      None
+    }
   }
 
   /**

--- a/src/test/scala/com/beachape/filemanagement/WatchServiceTaskSpec.scala
+++ b/src/test/scala/com/beachape/filemanagement/WatchServiceTaskSpec.scala
@@ -42,7 +42,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
     describe("for ENTRY_CREATE") {
 
       it("should cause ENTRY_CREATE events to be detectable for a directory path") {
-        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_CREATE)
+        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_CREATE, None)
         Files.createTempFile(tempDirPath, "hello", ".there2").toFile.deleteOnExit()
         var eventList = watchKey.pollEvents
         while (eventList.isEmpty){
@@ -54,7 +54,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
       }
 
       it("should cause ENTRY_CREATE events to be detectable for a file path") {
-        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_CREATE)
+        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_CREATE, None)
         Files.createTempFile(tempDirPath, "hello", ".there2").toFile.deleteOnExit()
         var eventList = watchKey.pollEvents
         while (eventList.isEmpty){
@@ -68,7 +68,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
       describe("implicit testing of #contextAbsolutePath") {
 
         it("should have the correct path in the event") {
-          val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_CREATE)
+          val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_CREATE, None)
           val fileCreated = Files.createTempFile(tempDirPath, "hello", ".there2")
           fileCreated.toFile.deleteOnExit()
           var eventList = watchKey.pollEvents
@@ -91,7 +91,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
 
       it("should cause ENTRY_DELETE events to be detectable for a directory path") {
         val fileToDelete  = Files.createTempFile(tempDirPath, "test", ".file")
-        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_DELETE)
+        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_DELETE, None)
         fileToDelete.toFile.delete()
         var eventList = watchKey.pollEvents()
         while (eventList.isEmpty){
@@ -104,7 +104,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
 
       it("should cause ENTRY_DELETE events to be detectable for a file path") {
         val fileToDelete  = Files.createTempFile(tempDirPath, "test", ".file")
-        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_DELETE)
+        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_DELETE, None)
         fileToDelete.toFile.delete()
         var eventList = watchKey.pollEvents()
         while (eventList.isEmpty){
@@ -119,7 +119,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
 
         it("should have the correct path in the event") {
           val fileToDelete  = Files.createTempFile(tempDirPath, "test", ".file")
-          val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_DELETE)
+          val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_DELETE, None)
           fileToDelete.toFile.delete()
           var eventList = watchKey.pollEvents()
           while (eventList.isEmpty){
@@ -139,7 +139,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
     describe("for ENTRY_MODIFY") {
 
       it("should cause ENTRY_MODIFY events to be detectable for a directory path") {
-        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_MODIFY)
+        val Some(watchKey) = watchServiceTask.watch(tempDirPath, ENTRY_MODIFY, None)
         val writer = new BufferedWriter(new FileWriter(tempFileInTempDir.toFile))
         writer.write(
           """
@@ -155,7 +155,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
       }
 
       it("should cause ENTRY_MODIFY events to be detectable for a file path") {
-        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_MODIFY)
+        val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_MODIFY, None)
         val writer = new BufferedWriter(new FileWriter(tempFileInTempDir.toFile))
         writer.write(
           """
@@ -173,7 +173,7 @@ class WatchServiceTaskSpec extends TestKit(ActorSystem("testSystem"))
       describe("implicit testing of #contextAbsolutePath") {
 
         it("should have the correct path in the event") {
-          val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_MODIFY)
+          val Some(watchKey) = watchServiceTask.watch(tempFileInTempDir, ENTRY_MODIFY, None)
           val writer = new BufferedWriter(new FileWriter(tempFileInTempDir.toFile))
           writer.write(
             """


### PR DESCRIPTION
Enable to use specified modifier from 3rdParty (e.g. com.sun.nio.file.SensitivityWatchEventModifier) as option for watchService registration.
