### PR TITLE
Remove default value for RxMonitor.apply's actorSystem

### DIFF
--- a/src/main/scala/com/beachape/filemanagement/RxMonitor.scala
+++ b/src/main/scala/com/beachape/filemanagement/RxMonitor.scala
@@ -16,10 +16,10 @@ object RxMonitor {
   /**
    * Returns an RxMonitor instance
    *
-   * @param actorSystem implicit parameter for an Actor system. Defaults to one called "actorSystem"
+   * @param actorSystem implicit parameter for an Actor system.
    * @return
    */
-  def apply(implicit actorSystem: ActorSystem = ActorSystem("actorSystem")): RxMonitor = new RxMonitor(actorSystem)
+  def apply()(implicit actorSystem: ActorSystem): RxMonitor = new RxMonitor(actorSystem)
 }
 
 /**

--- a/src/test/scala/com/beachape/filemanagement/RxMonitorSpec.scala
+++ b/src/test/scala/com/beachape/filemanagement/RxMonitorSpec.scala
@@ -1,6 +1,8 @@
 package com.beachape.filemanagement
 
-import org.scalatest.{PrivateMethodTester, Matchers, FunSpec}
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.scalatest.{PrivateMethodTester, Matchers, FunSpecLike}
 import java.nio.file.{Files, Path}
 import rx.lang.scala.Observer
 import com.beachape.filemanagement.Messages.EventAtPath
@@ -8,7 +10,7 @@ import scala.concurrent.Promise
 import org.scalatest.concurrent.ScalaFutures
 import java.nio.file.StandardWatchEventKinds._
 
-class RxMonitorSpec extends FunSpec with Matchers with PrivateMethodTester with ScalaFutures {
+class RxMonitorSpec extends TestKit(ActorSystem("testSystem")) with FunSpecLike with Matchers with PrivateMethodTester with ScalaFutures {
 
   trait Context {
     val tempDirPath = Files.createTempDirectory("root")


### PR DESCRIPTION
I would argue this variation is less counter-intuitive, and that requiring the user to manage their own ActorSystem is preferable.

Calling `RxMonitor()` causes the creation of an ActorSystem, which can be unexpected in situations where an ActorySystem is already implicitly in scope. To achieve expected behavior, you have to instead call `RxMonitor` -- without parentheses. To me, this distinction is counter-intuitive, and it's easy to wind up with two parallel ActorSystems. Further: since RxMonitor's default ActorSystem is not directly exposed and not stopped when calling the RxMonitor instance's stop() method, shutting it down is difficult and leads to applications that hang.