### PR TITLE
Add RegisterSubscriber-esque messages: Forward Path events to ActorRefs

### DIFF
--- a/src/main/scala/com/beachape/filemanagement/Messages.scala
+++ b/src/main/scala/com/beachape/filemanagement/Messages.scala
@@ -1,5 +1,6 @@
 package com.beachape.filemanagement
 
+import akka.actor.ActorRef
 import com.beachape.filemanagement.RegistryTypes._
 import java.nio.file.{ Path, WatchEvent }
 import java.nio.file.WatchEvent.Modifier
@@ -21,8 +22,25 @@ object Messages {
     def recursive: Boolean
     def path: Path
     def callback: Callback
-    def bossy: Boolean
+    def bossy: Boolean = false // "Bossy" means whether or not a message is supposed to remove all other callbacks
     def persistent: Boolean
+  }
+
+  /**
+   * Trait to make a message definition "Bossy", meaning it will remove all other callbacks for a specific path and
+   * event type
+   */
+  sealed trait BossyMessage { this: RegisterCallbackMessage =>
+    final override def bossy: Boolean = true
+  }
+
+  /**
+   * Abstract class to make it easy to define a registration that forwards EvenAtPath messages to a particular [[ActorRef]]
+   */
+  sealed abstract class ForwardToSubscriber(subscriber: ActorRef) { this: RegisterCallbackMessage =>
+    val callback: Callback = { path =>
+      subscriber ! EventAtPath(event, path)
+    }
   }
 
   /**
@@ -39,42 +57,79 @@ object Messages {
    * path for callback
    *
    * @param event WatchEvent.Kind[Path], one of ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE
-   * @param recursive Boolean To recursively register the callback or not, defaults to false
-   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
    * @param path Path (Java object) pointing to a file/directory
    * @param callback (Path) => Unit type function
+   * @param recursive Boolean To recursively register the callback or not, defaults to false
+   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
    */
   sealed case class RegisterCallback(
-      event: WatchEvent.Kind[Path],
-      path: Path,
-      callback: Callback,
-      modifier: Option[Modifier] = None,
-      recursive: Boolean = false,
-      persistent: Boolean = false) extends RegisterCallbackMessage {
-    val bossy = false
-  }
+    event: WatchEvent.Kind[Path],
+    path: Path,
+    callback: Callback,
+    modifier: Option[Modifier] = None,
+    recursive: Boolean = false,
+    persistent: Boolean = false) extends RegisterCallbackMessage
 
   /**
-   * Message case class for telling a MonitorActor that the callback contained
-   * will be the ONLY callback registered for the specific path.
+   * Message case class for registering an ActorRef to receive [[EventAtPath]] messages when something happens
+   * at a path
+   *
+   * @param event WatchEvent.Kind[Path], one of ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE
+   * @param path Path (Java object) pointing to a file/directory
+   * @param subscriber ActorRef that you want to receive notifications on
+   * @param modifier Optional Modifier that qualifies how a Watchable is registered with a WatchService.
+   * @param recursive Boolean To recursively register the callback or not, defaults to false
+   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
+   */
+  sealed case class RegisterSubscriber(event: WatchEvent.Kind[Path],
+    path: Path,
+    subscriber: ActorRef,
+    modifier: Option[Modifier] = None,
+    recursive: Boolean = false,
+    persistent: Boolean = false) extends ForwardToSubscriber(subscriber) with RegisterCallbackMessage
+
+  /**
+   * Message case class for telling a MonitorActor that the callback contained will be the ONLY callback registered for
+   * the specific path.
    *
    * Mostly intended to be used with RxMonitor; hence the terrible name.
    *
    * @param event WatchEvent.Kind[Path], one of ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE
-   * @param recursive Boolean to specify to recursively register the callback or not, defaults to false
-   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
    * @param path Path (Java object) pointing to a file/directory
    * @param callback (Path) => Unit type function
+   * @param modifier Optional Modifier that qualifies how a Watchable is registered with a WatchService.
+   * @param recursive Boolean to specify to recursively register the callback or not, defaults to false
+   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
    */
   sealed case class RegisterBossyCallback(
-      event: WatchEvent.Kind[Path],
-      path: Path,
-      callback: Callback,
-      modifier: Option[Modifier] = None,
-      recursive: Boolean = false,
-      persistent: Boolean = false) extends RegisterCallbackMessage {
-    val bossy = true
-  }
+    event: WatchEvent.Kind[Path],
+    path: Path,
+    callback: Callback,
+    modifier: Option[Modifier] = None,
+    recursive: Boolean = false,
+    persistent: Boolean = false) extends RegisterCallbackMessage with BossyMessage
+
+  /**
+   * Message case class for registering an ActorRef to receive [[EventAtPath]] messages when something happens
+   * at a path.
+   *
+   * This is different from RegisterSubscriber in that when something happens at the provided path, the only thing
+   * that will happen is the ActorRef you provided will get notified.
+   *
+   * @param event WatchEvent.Kind[Path], one of ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE
+   * @param path Path (Java object) pointing to a file/directory
+   * @param subscriber ActorRef that you want to receive notifications on
+   * @param modifier Optional Modifier that qualifies how a Watchable is registered with a WatchService.
+   * @param recursive Boolean To recursively register the callback or not, defaults to false
+   * @param persistent Boolean To automatically add the same callback to new files or not, defaults to false
+   */
+  sealed case class RegisterBossySubscriber(
+    event: WatchEvent.Kind[Path],
+    path: Path,
+    subscriber: ActorRef,
+    modifier: Option[Modifier] = None,
+    recursive: Boolean = false,
+    persistent: Boolean = false) extends ForwardToSubscriber(subscriber) with RegisterCallbackMessage with BossyMessage
 
   /**
    * Message case class for telling a MonitorActor to un-register a
@@ -96,6 +151,7 @@ object Messages {
 
   /**
    * Message case class for telling a CallbackActor to perform a callback
+   *
    * @param path Path (Java object) pointing to a file/directory
    * @param callback (Path) => Unit type function
    */

--- a/src/main/scala/com/beachape/filemanagement/MonitorActor.scala
+++ b/src/main/scala/com/beachape/filemanagement/MonitorActor.scala
@@ -172,7 +172,7 @@ class MonitorActor(concurrency: Int = 5, dedupeTime: FiniteDuration = 1.5.second
       )
     }
 
-    case _ => log.error("MonitorActor received an unexpected message :( !")
+    case unexpected => log.error(s"MonitorActor received an unexpected message :( !\n\n $unexpected")
   }
 
   /**
@@ -344,6 +344,8 @@ class MonitorActor(concurrency: Int = 5, dedupeTime: FiniteDuration = 1.5.second
     val registerMessage = m match {
       case m: RegisterCallback => m.copy(path = p)
       case m: RegisterBossyCallback => m.copy(path = p)
+      case m: RegisterSubscriber => m.copy(path = p)
+      case m: RegisterBossySubscriber => m.copy(path = p)
     }
     monitorActor ! registerMessage
   }


### PR DESCRIPTION
Exposes an API to make it possible to forward `EventAtPath` messages directly to `ActorRefs` via `RegisterSubscriber`. Should handle #60 

For simplicity, this is implemented on top of the existing Callback based model.